### PR TITLE
Add initial spec version

### DIFF
--- a/index.html
+++ b/index.html
@@ -55,8 +55,8 @@
   <h2>Abstract</h2>
   <p>
     The scope of this specification is to provide a way to query over quads, as defined in the <a href="http://rdf.js.org/data-model-spec/#quad-interface">RDF/JS: Data model specification</a>.
-    Similar to the <a href="http://rdf.js.org/data-model-spec/">RDF/JS: Data model specification</a>, this is a low-level specification that provides only essential methods for working with query engines.
-    High-level interfaces that work with quads can and should be using libraries that implement this interface.
+    Similar to the <a href="http://rdf.js.org/data-model-spec/">RDF/JS: Data model specification</a>, this is a low-level specification that provides only essential methods for working across query engine component.
+    High-level querying interfaces can and should be using libraries that implement this interface.
   </p>
   <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
   <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
@@ -83,6 +83,22 @@
     <li>Interfaces do not conflict with other RDF/JS interfaces, and users and implementers of purely other RDF/JS interfaces should not be aware of the interfaces in this specification if they are not needed.</li>
     <li>Data interfaces should not contain methods, as to enable straightforward transmission over low-level communication protocols such as Web Assembly.</li>
   </ul>
+</section>
+
+<section>
+  <h2>Filter expression interfaces</h2>
+  
+  This section introduces interfaces that enable quad sources to be filtered based on a declarative expression.
+  
+  <section>
+    <h2>Goals</h2>
+    <ul>
+      <li>Query engines MUST be able to push down filters into sources.</li>
+      <li>Query engines MUST be able to detect what expressions are supported by sources.</li>
+      <li>Query engines MUST be able to obtain the estimated cardinality of any supported expression.</li>
+    </ul>
+  </section>
+
 </section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -226,6 +226,72 @@
       If defined, this type MUST correspond to the type in <code>QueryResultMetadataCount</code>.
     </p>
   </section>
+  
+  <section data-dfn-for="Expression">
+    <h3><dfn>Expression</dfn> interface</h3>
+
+    <pre class="idl">
+    interface Expression {
+      attribute string expressionType;
+    };
+    </pre>
+    
+    <p>
+      <code>QueryResultMetadataOptions</code> is an abstract interface that represents a generic expression over a stream of quads.
+    </p>
+    <p>
+      <dfn>expressionType</dfn> contains a value that identifies the concrete interface of the expression, since the Expression itself is not directly instantiated.
+      Possible values include <code>"operator"</code> and <code>"term"</code>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="OperatorExpression">
+    <h3><dfn>OperatorExpression</dfn> interface</h3>
+
+    <pre class="idl">
+    interface OperatorExpression {
+      attribute string expressionType;
+      attribute string operator;
+      attribute FrozenArray&lt;Expression&gt; args;
+    };
+    </pre>
+    
+    <p>
+      An <code>OperatorExpression</code> is represents an expression that applies a given operator on given sub-expressions.
+    </p>
+    <p>
+      <dfn>expressionType</dfn> contains the constant <code>"operator"</code>.
+    </p>
+    <p>
+      <dfn>operator</dfn> contains a value that identifies an operator.
+      Possible values can be found in TODO.
+    </p>
+    <p>
+      <dfn>args</dfn> contains an array of <code>Expression</code>'s on to which the given operator applies.
+      The length of this array depends on the operator.
+    </p>
+  </section>
+  
+  <section data-dfn-for="TermExpression">
+    <h3><dfn>TermExpression</dfn> interface</h3>
+
+    <pre class="idl">
+    interface TermExpression {
+      attribute string expressionType;
+      attribute Term term;
+    };
+    </pre>
+    
+    <p>
+      A <code>TermExpression</code> is an expression that contains a <a href="http://rdf.js.org/data-model-spec/#term-interface"><code>Term</code></a>.
+    </p>
+    <p>
+      <dfn>expressionType</dfn> contains the constant <code>"term"</code>.
+    </p>
+    <p>
+      <dfn>term</dfn> contains a <a href="http://rdf.js.org/data-model-spec/#term-interface"><code>Term</code></a>.
+    </p>
+  </section>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -304,6 +304,27 @@
       <dfn>term</dfn> contains a <a href="http://rdf.js.org/data-model-spec/#term-interface"><code>Term</code></a>.
     </p>
   </section>
+  
+  <section data-dfn-for="ExpressionFactory">
+    <h3><dfn>ExpressionFactory</dfn> interface</h3>
+
+    <pre class="idl">
+    interface ExpressionFactory {
+      OperatorExpression operatorExpression(string operator, sequence&lt;Expression&gt; args);
+      TermExpression termExpression(Term term);
+    };
+    </pre>
+    
+    <p>
+      <code>ExpressionFactory</code> enables expressions to be created in an idiomatic manner.
+    </p>
+    <p>
+      <dfn>operatorExpression</dfn> creates a new <code>OperatorExpression</code> instance for the given operator and array of arguments.
+    </p>
+    <p>
+      <dfn>termExpression</dfn> creates a new <code>TermExpression</code> instance for the given term.
+    </p>
+  </section>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -105,7 +105,7 @@
 
     <pre class="idl">
     interface FilterableSource {
-      FilterableSourceResult matchExpression (
+      FilterResult matchExpression (
         optional Term? subject,
         optional Term? predicate,
         optional Term? obj,
@@ -136,6 +136,34 @@
     <p>
       When an <code>Expression</code> parameter is defined, the complete quad stream is filtered according to this expression.
       When it is undefined, no filter is applied, and the semantics are identical to that of <a href="https://rdf.js.org/stream-spec/#source-interface">Source.match</a>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="FilterResult">
+    <h3><dfn>FilterResult</dfn> interface</h3>
+
+    <pre class="idl">
+    interface FilterResult {
+      Stream quads();
+      Promise&lt;QueryResultMetadata&gt; metadata(optional QueryResultMetadataOptions? options);
+      Promise&lt;boolean&gt; isSupported();
+    };
+    </pre>
+    
+    <p>
+      A <code>FilterResult</code> is an object that represents the result of a filter expression of <code>FilterableSource</code> for a given quad pattern and expression.
+      It MAY create results lazily after one of its methods is invoked.
+    </p>
+    <p>
+      <dfn>quads()</dfn> Returns a <a href="https://rdf.js.org/stream-spec/#stream-interface"><code>Stream<Quad></code></a> containing all the quads that matched the given quad pattern and expression.
+    </p>
+    <p>
+      <dfn>metadata()</dfn> Asynchronously returns a <code>QueryResultMetadata</code>, that contains the metadata of the current result.
+    </p>
+    <p>
+      <dfn>isSupported()</dfn> Asynchronously returns a boolean indicating if the requested expression is supported by the <code>FilterableSource</code>.
+      If it returns <code>true</code>, <code>quads()</code> and <code>metadata()</code> MAY produce a valid result.
+      If it returns <code>false</code>, <code>quads()</code> MUST return a stream emitting an error, and <code>metadata()</code> MUST reject.
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -52,8 +52,15 @@
 </head>
 <body>
 <section id="abstract">
+  <h2>Abstract</h2>
   <p>
+    The scope of this specification is to provide a way to query over quads, as defined in the <a href="http://rdf.js.org/data-model-spec/#quad-interface">RDF/JS: Data model specification</a>.
+    Similar to the <a href="http://rdf.js.org/data-model-spec/">RDF/JS: Data model specification</a>, this is a low-level specification that provides only essential methods for working with query engines.
+    High-level interfaces that work with quads can and should be using libraries that implement this interface.
   </p>
+  <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
+  <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
+  <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>
 </section>
 
 <section id="sotd">

--- a/index.html
+++ b/index.html
@@ -331,16 +331,494 @@
 <section>
   <h2>Expression operators</h2>
 
-  This section introduces a non-exhaustive list of operators that MAY be used in <code>OperatorExpression</code>.
+  <p>This section introduces a non-exhaustive list of operators that MAY be used in <code>OperatorExpression</code>.</p>
 
-  Implementers MAY decide to support only a subset of these operators.
+  <p>Implementers MAY decide to support only a subset of these operators.</p>
   
-
-  <div class="warning" title="TODO">
-    <p>
-      Add tables
-    </p>
-  </div>
+  <p>We omit any formal semantics behind these operators in this specification, and refer to their <a href="https://www.w3.org/TR/sparql11-query/">SPARQL 1.1. semantics</a>.</p>
+  
+  <section>
+    <h2>Relational operators</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#OperatorMapping">relational operators</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>!</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:boolean)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>The inverse of the given boolean value.</td>
+        </tr>
+        <tr>
+          <td><code>uplus</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The positive value of the given numeric value.</td>
+        </tr>
+        <tr>
+          <td><code>uminus</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The negative value of the given numeric value.</td>
+        </tr>
+        <tr>
+          <td><code>*</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The multiplication of the given values.</td>
+        </tr>
+        <tr>
+          <td><code>/</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The division of the given values.</td>
+        </tr>
+        <tr>
+          <td><code>+</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The addition of the given values.</td>
+        </tr>
+        <tr>
+          <td><code>-</code></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>The subtraction of the given values.</td>
+        </tr>
+        <tr>
+          <td><code>=</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the given values are equal. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+        <tr>
+          <td><code>!=</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the given values are not equal. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+        <tr>
+          <td><code>&lt;</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the first value is lesser than the second value. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+        <tr>
+          <td><code>&gt;</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the first value is greater than the second value. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+        <tr>
+          <td><code>&le;</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the first value is lesser than or equal to the second value. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+        <tr>
+          <td><code>&ge;</code></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the first value is greater than or equal to the second value. If the terms are <code>Literal</code>s, their lexical value is compared</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  
+  <section>
+    <h2>Term operators</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-rdfTerms">operators on RDF terms</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-isIRI"><code>isiri</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if term is a <code>NamedNode</code>. Returns false otherwise.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-isBlank"><code>isblank</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if term is a <code>BlankNode</code>. Returns false otherwise.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-isLiteral"><code>isliteral</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if term is a <code>Literal</code>. Returns false otherwise.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-isNumeric"><code>isnumeric</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if term is a <code>Literal</code> with a numeric datatype. Returns false otherwise.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-str"><code>str</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the (lexical) string representation of the given term.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-lang"><code>lang</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the language tag of the given <code>Literal</code>, or the empty string if the <code>Literal</code> has no language tag.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-datatype"><code>datatype</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code></li>
+            </ol>
+          </td>
+          <td><code>NamedNode</code></td>
+          <td>Returns the datatype of the given <code>Literal</code>.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-iri"><code>iri</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code> (xsd:string), <code>NamedNode</code></li>
+            </ol>
+          </td>
+          <td><code>NamedNode</code></td>
+          <td>Resolve the given IRI against the base IRI of the current context.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-bnode"><code>bnode</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code> (xsd:string), <em>empty</em></li>
+            </ol>
+          </td>
+          <td><code>BlankNode</code></td>
+          <td>Create a new blank node with the given label if provided.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strdt"><code>strdt</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code> (xsd:string)</li>
+              <li><code>NamedNode</code></li>
+            </ol>
+          </td>
+          <td><code>Literal</code></td>
+          <td>Returns a new <code>Literal</code> with the given datatype.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strlang"><code>strlang</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal</code> (xsd:string)</li>
+              <li><code>Literal</code> (xsd:string)</li>
+            </ol>
+          </td>
+          <td><code>Literal</code></td>
+          <td>Returns a new <code>Literal</code> with the given language tag.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-uuid"><code>uuid</code></a></td>
+          <td>/</td>
+          <td><code>NamedNode</code></td>
+          <td>Returns a new <code>NamedNode</code> following the <a href="https://www.ietf.org/rfc/rfc4122.txt">UUID URN scheme</a>.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-struuid"><code>struuid</code></a></td>
+          <td>/</td>
+          <td><code>Literal</code> (xsd:string)</td>
+          <td>Returns a new <code>Literal</code> following the <a href="https://www.ietf.org/rfc/rfc4122.txt">UUID URN scheme</a>.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  
+  <section>
+    <h2>String operators</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-strings">string operators</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strlen"><code>strlen</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the number of characters of the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-substr"><code>substr</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:integer)</code></li>
+              <li><code>Literal (xsd:integer)</code> (optional)</li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the substring of the given string starting from the given position (second parameter) with the given length (third parameter). If no third parameter is provided, then the maximum length is taken.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-ucase"><code>ucase</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Transform each character in the given string to upper case.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-lcase"><code>lcase</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Transform each character in the given string to lower case.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strstarts"><code>strstarts</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Check if the given string starts with the given second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strends"><code>strends</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Check if the given string ends with the given second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strcontains"><code>strcontains</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Check if the given string contains the given second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strbefore"><code>strbefore</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>From the given first string, find the full string that occurs before the given second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-strafter"><code>strafter</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>From the given first string, find the full string that occurs after the given second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-encode"><code>encode_for_uri</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Apply URI encoding on the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-concat"><code>concat</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li> (variable number of arguments)
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Concatenation of all the given strings.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-langMatches"><code>langmatches</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>If the language tag of the first literal matches the second string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-regex"><code>regex</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code> (optional)</li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Check if on the given first string, the given second regular expression matches. The third parameter indicates optional regex flags.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-replace"><code>replace</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code></li>
+              <li><code>Literal (xsd:string)</code> (optional)</li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>In the given first string, match the given second regular expression, and replace it with the given third string. The fourth parameter indicates optional regex flags.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  
+  <section>
+    <h2>Functional forms</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-forms">functional operators</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-bound"><code>bound</code></a></td>
+          <td>
+            <ol>
+              <li><code>Variable</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if the given variable is bound to a value. Returns false otherwise.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
 </section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -166,6 +166,66 @@
       If it returns <code>false</code>, <code>quads()</code> MUST return a stream emitting an error, and <code>metadata()</code> MUST reject.
     </p>
   </section>
+  
+  <section data-dfn-for="QueryResultMetadata">
+    <h3><dfn>QueryResultMetadata</dfn> interface</h3>
+
+    <pre class="idl">
+    interface QueryResultMetadata {
+      attribute QueryResultMetadataCount? count;
+    };
+    </pre>
+    
+    <p>
+      A <code>QueryResultMetadata</code> is an object that represents contains metadata bout a certain query result,
+      such as invoking <code>FilterableSource.matchExpression</code>.
+    </p>
+    <p>
+      <dfn>count</dfn> is an optional field that contains metadata about the number of quads in the result stream.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryResultMetadataCount">
+    <h3><dfn>QueryResultMetadataCount</dfn> interface</h3>
+
+    <pre class="idl">
+    interface QueryResultMetadataCount {
+      attribute string type;
+      attribute number value;
+    };
+    </pre>
+    
+    <p>
+      <code>QueryResultMetadataCount</code> is part of the <code>QueryResultMetadata</code> interface
+      to represent metadata about the number of quads in the result stream.
+    </p>
+    <p>
+      <dfn>type</dfn> indicates the type of counting that was done, and MUST either be <code>"estimate"</code> or <code>"exact"</code>.
+    </p>
+    <p>
+      <dfn>value</dfn> indicates an estimate of the number of quads in the stream if <code>type = "estimate"</code>,
+      or the exact number  of quads in the stream if <code>type = "exact"</code>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryResultMetadata">
+    <h3><dfn>QueryResultMetadataOptions</dfn> interface</h3>
+
+    <pre class="idl">
+    interface QueryResultMetadataOptions {
+      attribute string? count;
+    };
+    </pre>
+    
+    <p>
+      A <code>QueryResultMetadataOptions</code> is an object that gives suggestions on what type of metadata is desired,
+      such as when invoking <code>FilterResult.metadata</code>.
+    </p>
+    <p>
+      <dfn>count</dfn> is an optional field that MAY either contain <code>"estimate"</code> or <code>"exact"</code>.
+      If defined, this type MUST correspond to the type in <code>QueryResultMetadataCount</code>.
+    </p>
+  </section>
 
 </section>
 

--- a/index.html
+++ b/index.html
@@ -14,8 +14,24 @@
       issueBase: "https://github.com/rdfjs/query-spec/issues/",
       githubAPI: "https://api.github.com/repos/rdfjs/query-spec",
       // TODO: testSuiteURIkey: "",
-      editors: [],
-      authors:  [],
+      editors: [
+          {
+            name: "Ruben Taelman",
+            url: "https://www.rubensworks.net/#me",
+            company: "Ghent University – imec",
+            companyURL: "http://idlab.ugent.be/",
+            w3cid: 84199
+          }
+      ],
+      authors:  [
+          {
+            name: "Ruben Taelman",
+            url: "https://www.rubensworks.net/#me",
+            company: "Ghent University – imec",
+            companyURL: "http://idlab.ugent.be/",
+            w3cid: 84199
+          }
+      ],
       bugTracker:             {
         open: "https://github.com/rdfjs/query-spec/issues?utf8=%E2%9C%93&q=is%3Aissue%20is%3Aopen%20",
         new:  "https://github.com/rdfjs/query-spec/issues/new"

--- a/index.html
+++ b/index.html
@@ -492,9 +492,9 @@
   </section>
   
   <section>
-    <h2>Term operators</h2>
+    <h2>Term functions</h2>
     
-    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-rdfTerms">operators on RDF terms</a>.
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-rdfTerms">functions on RDF terms</a>.
   
     <table>
       <thead>
@@ -630,9 +630,9 @@
   </section>
   
   <section>
-    <h2>String operators</h2>
+    <h2>String functions</h2>
     
-    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-strings">string operators</a>.
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-strings">string functions</a>.
   
     <table>
       <thead>
@@ -797,6 +797,328 @@
   </section>
   
   <section>
+    <h2>Numerical functions</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-numerics">numerical functions</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-abs"><code>abs</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>Returns the absolute value of the given numerical term.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-round"><code>round</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>Returns the number with no fractional part that is closest to the argument, with preference for rounding up.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-ceil"><code>ceil</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>Returns the smallest (closest to negative infinity) number with no fractional part that is not less than the value of arg.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-floor"><code>floor</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (numeric)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (numeric)</code></td>
+          <td>Returns the largest (closest to positive infinity) number with no fractional part that is not greater than the value of arg.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-rand"><code>rand</code></a></td>
+          <td>
+            /
+          </td>
+          <td><code>Literal (xsd:double)</code></td>
+          <td>Returns a pseudo-random, number between 0 (inclusive) and 1.0e0 (exclusive). Different numbers can be produced every time this function is invoked. Numbers should be produced with approximately equal probability.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Date and time functions</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-date-time">date and time functions</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-now"><code>now</code></a></td>
+          <td>
+            /
+          </td>
+          <td><code>Literal (xsd:dateTime)</code></td>
+          <td>Returns an XSD dateTime value for the current query execution. All calls to this function in any one query execution must return the same value.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-year"><code>year</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the year of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-month"><code>month</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the month of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-day"><code>day</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the day of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-hours"><code>hours</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the hours of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-minutes"><code>minutes</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the minutes of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-seconds"><code>seconds</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Returns the seconds of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-timezone"><code>timezone</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:dayTimeDuration)</code></td>
+          <td>Returns the timezone part of the given date.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-tz"><code>tz</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:dateTime)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the timezone part of the given date.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>Hash functions</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-hash">hash functions</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-md5"><code>md5</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the MD5 checksum of the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-sha1"><code>sha1</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the SHA1 checksum of the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-sha256"><code>sha256</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the SHA256 checksum of the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-sha384"><code>sha384</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the SHA384 checksum of the given string.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-sha512"><code>sha512</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:string)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Returns the SHA512 checksum of the given string.</td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+
+  <section>
+    <h2>XPath constructor functions</h2>
+    
+    This section introduces <a href="https://www.w3.org/TR/sparql11-query/#FunctionMapping">XPath constructor functions</a>.
+  
+    <table>
+      <thead>
+        <tr><th>Name</th><th>Input</th><th>Output</th><th>Description</th></tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#string</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:string)</code></td>
+          <td>Cast the given term to <code>xsd:string</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#float</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:float)</code></td>
+          <td>Cast the given term to <code>xsd:float</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#double</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:double)</code></td>
+          <td>Cast the given term to <code>xsd:double</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#decimal</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:decimal)</code></td>
+          <td>Cast the given term to <code>xsd:decimal</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#integer</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:integer)</code></td>
+          <td>Cast the given term to <code>xsd:integer</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#dateTime</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:dateTime)</code></td>
+          <td>Cast the given term to <code>xsd:dateTime</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#date</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:date)</code></td>
+          <td>Cast the given term to <code>xsd:date</code></td>
+        </tr>
+        <tr>
+          <td><code>http://www.w3.org/2001/XMLSchema#boolean</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Cast the given term to <code>xsd:boolean</code></td>
+        </tr>
+      </tbody>
+    </table>
+  </section>
+  
+  <section>
     <h2>Functional forms</h2>
     
     This section introduces <a href="https://www.w3.org/TR/sparql11-query/#func-forms">functional operators</a>.
@@ -815,6 +1137,94 @@
           </td>
           <td><code>Literal (xsd:boolean)</code></td>
           <td>Returns true if the given variable is bound to a value. Returns false otherwise.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-if"><code>if</code></a></td>
+          <td>
+            <ol>
+              <li><code>Expression</code></li>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Term</code></td>
+          <td>Evaluates the expression as <a href="https://www.w3.org/TR/sparql11-query/#ebv">effective boolean value</a>. Returns the second argument if true, otherwise the third argument.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-coalesce"><code>coalesce</code></a></td>
+          <td>
+            <ol>
+              <li><code>Expression</code> (variable number of arguments)</li>
+            </ol>
+          </td>
+          <td><code>Term</code></td>
+          <td>Returns the first expression result that evaluates without an error.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-logical-or"><code>||</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:boolean)</code></li>
+              <li><code>Literal (xsd:boolean)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns a logical OR of left and right. Note that logical-or operates on the <a href="https://www.w3.org/TR/sparql11-query/#ebv">effective boolean value</a> of its arguments.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-logical-and"><code>&amp;&amp;</code></a></td>
+          <td>
+            <ol>
+              <li><code>Literal (xsd:boolean)</code></li>
+              <li><code>Literal (xsd:boolean)</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns a logical AND of left and right. Note that logical-or operates on the <a href="https://www.w3.org/TR/sparql11-query/#ebv">effective boolean value</a> of its arguments.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal"><code>=</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if both terms are the same follow these <a href="https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal">rules</a>. A type error is produced if both arguments are literals but not the same.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-sameTerm"><code>sameterm</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Term</code></li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Returns true if both terms are the same follow these <a href="https://www.w3.org/TR/sparql11-query/#func-RDFterm-equal">rules</a>. False is returned instead of type errors.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-in"><code>in</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Expression</code> (variable number of arguments)</li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Tests whether the RDF term on the left-hand side is found in the values of list of expressions on the right-hand side.</td>
+        </tr>
+        <tr>
+          <td><a href="https://www.w3.org/TR/sparql11-query/#func-not-in"><code>notin</code></a></td>
+          <td>
+            <ol>
+              <li><code>Term</code></li>
+              <li><code>Expression</code> (variable number of arguments)</li>
+            </ol>
+          </td>
+          <td><code>Literal (xsd:boolean)</code></td>
+          <td>Tests whether the RDF term on the left-hand side is not found in the values of list of expressions on the right-hand side.</td>
         </tr>
       </tbody>
     </table>

--- a/index.html
+++ b/index.html
@@ -21,6 +21,13 @@
             company: "Ghent University – imec",
             companyURL: "http://idlab.ugent.be/",
             w3cid: 84199
+          },
+          {
+            name: "Jacopo Scazzosi",
+            url: "https://jacoscaz.com/#me",
+            company: "Beautiful Interactions s.r.l.",
+            companyURL: "https://beautifulinteractions.com/",
+            w3cid: 72858
           }
       ],
       authors:  [
@@ -30,6 +37,13 @@
             company: "Ghent University – imec",
             companyURL: "http://idlab.ugent.be/",
             w3cid: 84199
+          },
+          {
+            name: "Jacopo Scazzosi",
+            url: "https://jacoscaz.com/#me",
+            company: "Beautiful Interactions s.r.l.",
+            companyURL: "https://beautifulinteractions.com/",
+            w3cid: 72858
           }
       ],
       bugTracker:             {

--- a/index.html
+++ b/index.html
@@ -70,6 +70,10 @@
     and future libraries interoperable. This definition strives to provide the minimal necessary
     interface to enable interoperability of RDF querying libraries.
   </p>
+  <p>
+    <strong>Currently, this specification only provides interfaces that enable filtering quads based on expressions.</strong>
+    Additional interfaces for more general querying support will be defined in the future.
+  </p>
 </section>
 
 </body>

--- a/index.html
+++ b/index.html
@@ -76,5 +76,14 @@
   </p>
 </section>
 
+<section>
+  <h2>Design elements and principles</h2>
+  <ul>
+    <li><em>All <a href="http://rdf.js.org/data-model-spec/#design-elements-and-principles">design elements and principles from the RDF/JS data model specification</a> apply here as well.</em></li>
+    <li>Interfaces do not conflict with other RDF/JS interfaces, and users and implementers of purely other RDF/JS interfaces should not be aware of the interfaces in this specification if they are not needed.</li>
+    <li>Data interfaces should not contain methods, as to enable straightforward transmission over low-level communication protocols such as Web Assembly.</li>
+  </ul>
+</section>
+
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -82,6 +82,7 @@
     <li><em>All <a href="http://rdf.js.org/data-model-spec/#design-elements-and-principles">design elements and principles from the RDF/JS data model specification</a> apply here as well.</em></li>
     <li>Interfaces do not conflict with other RDF/JS interfaces, and users and implementers of purely other RDF/JS interfaces should not be aware of the interfaces in this specification if they are not needed.</li>
     <li>Data interfaces should not contain methods, as to enable straightforward transmission over low-level communication protocols such as Web Assembly.</li>
+    <li>To enable querying over large graphs, interfaces should handle quads in a streaming manner, such as the <a href="https://rdf.js.org/stream-spec/">RDF/JS stream interfaces</a>.</li>
   </ul>
 </section>
 
@@ -97,6 +98,45 @@
       <li>Query engines MUST be able to detect what expressions are supported by sources.</li>
       <li>Query engines MUST be able to obtain the estimated cardinality of any supported expression.</li>
     </ul>
+  </section>
+
+  <section data-dfn-for="FilterableSource">
+    <h3><dfn>FilterableSource</dfn> interface</h3>
+
+    <pre class="idl">
+    interface FilterableSource {
+      FilterableSourceResult matchExpression (
+        optional Term? subject,
+        optional Term? predicate,
+        optional Term? obj,
+        optional Term? graph,
+        optional Expression? expression
+      );
+    };
+    </pre>
+    
+    <p>
+      A <code>FilterableSource</code> is an object that produces a <code>FilterableSourceResult</code> that can emit quads.
+      The emitted quads can be directly contained in this <code>FilterableSource</code> object, or they can be generated on the fly.
+    </p>
+    <p>
+      <code>FilterableSource</code> is not necessarily an extension of the <a href="https://rdf.js.org/stream-spec/#source-interface">RDF/JS Source interface</a>, but implementers MAY decide to implement both at the same time.
+    </p>
+    <p>
+      <dfn>matchExpression()</dfn> Returns a <code>FilterableSourceResult</code> that contains a quad stream that processes all quads matching the quad pattern and the expression.
+    </p>
+    <p>
+      When a <code>Term</code> parameter is defined, it must match each produced quad, according to the <a href="http://rdf.js.org/data-model-spec/#quad-interface"><code>Quad.equals</code></a> semantics. When it is undefined, it acts as a wildcard, and can match with any <code>Term</code>.
+    </p>
+    <p class="note">
+      When matching with <code>graph</code> set to <code>undefined</code> or <code>null</code>
+      it MUST match all the graphs (sometimes called <em>the union graph</em>). To match only <em>the default graph</em>
+      set <code>graph</code> to a <code>DefaultGraph</code>
+    </p>
+    <p>
+      When an <code>Expression</code> parameter is defined, the complete quad stream is filtered according to this expression.
+      When it is undefined, no filter is applied, and the semantics are identical to that of <a href="https://rdf.js.org/stream-spec/#source-interface">Source.match</a>.
+    </p>
   </section>
 
 </section>

--- a/index.html
+++ b/index.html
@@ -126,7 +126,10 @@
       <dfn>matchExpression()</dfn> Returns a <code>FilterableSourceResult</code> that contains a quad stream that processes all quads matching the quad pattern and the expression.
     </p>
     <p>
-      When a <code>Term</code> parameter is defined, it must match each produced quad, according to the <a href="http://rdf.js.org/data-model-spec/#quad-interface"><code>Quad.equals</code></a> semantics. When it is undefined, it acts as a wildcard, and can match with any <code>Term</code>.
+      When a <code>Term</code> parameter is defined, and is a <code>NamedNode</code>, <code>Literal</code> or <code>BlankNode</code>,
+      it must match each produced quad, according to the <a href="http://rdf.js.org/data-model-spec/#quad-interface"><code>Quad.equals</code></a> semantics.
+      When a <code>Term</code> parameter is a <code>Variable</code>,
+      or it is undefined, it acts as a wildcard, and can match with any <code>Term</code>.
     </p>
     <p class="note">
       When matching with <code>graph</code> set to <code>undefined</code> or <code>null</code>
@@ -135,7 +138,16 @@
     </p>
     <p>
       When an <code>Expression</code> parameter is defined, the complete quad stream is filtered according to this expression.
-      When it is undefined, no filter is applied, and the semantics are identical to that of <a href="https://rdf.js.org/stream-spec/#source-interface">Source.match</a>.
+      When it is undefined, no filter is applied.
+    </p>
+    <p>
+      If parameters of type <code>Variable</code> with an equal variable name are in place,
+      then the corresponding quad components in the resulting quad stream MUST be equal.
+    </p>
+    <p>
+      <code>Expression</code>'s MAY contain <code>Variable</code> <code>Term</code>'s.
+      If their variable names are equal to <code>Variable</code>'s in the given quad pattern,
+      then the <code>Expression</code> MUST be instantiated for each variable's binding in the resulting quad stream when applying the <code>Expression</code> filter.
     </p>
   </section>
   
@@ -264,7 +276,7 @@
     </p>
     <p>
       <dfn>operator</dfn> contains a value that identifies an operator.
-      Possible values can be found in TODO.
+      Possible values can be found in <a href="#expression-operators">the list of operators</a>.
     </p>
     <p>
       <dfn>args</dfn> contains an array of <code>Expression</code>'s on to which the given operator applies.
@@ -293,6 +305,21 @@
     </p>
   </section>
 
+</section>
+
+<section>
+  <h2>Expression operators</h2>
+
+  This section introduces a non-exhaustive list of operators that MAY be used in <code>OperatorExpression</code>.
+
+  Implementers MAY decide to support only a subset of these operators.
+  
+
+  <div class="warning" title="TODO">
+    <p>
+      Add tables
+    </p>
+  </div>
 </section>
 
 </body>


### PR DESCRIPTION
This initial version of the query spec aims to provide interfaces to enable filtering quads based on expressions.
This should enable different querying-related libraries to collaborate on evaluating filter expressions.
For example, one library could start evaluating a SPARQL query, but push down certain filters to another storage-level library for more efficient evaluation.

This PR is based on an internal document in collaboration with @jacoscaz (could you add your name to the authors/editors list?).

Other interfaces for other querying capabilities are out of scope for this PR.

Preview: https://raw.githack.com/rdfjs/query-spec/93c773cf55ac720c5bb1082e9023f4cb9c401c59/index.html