### PR TITLE
Sync respec contents with TS typings

### DIFF
--- a/index.html
+++ b/index.html
@@ -207,26 +207,126 @@
     </p>
     <p>
       <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Bindings</code> objects.
-      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>SELECT</code> query.
+      <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL <code>SELECT</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
     <p>
       <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Quad</code> objects.
-      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
+      <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
     <p>
       <dfn>queryBoolean()</dfn> is an optional method that asynchronously returns a <code>boolean</code>.
-      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>ASK</code> query.
+      <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL <code>ASK</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
     <p>
       <dfn>queryVoid()</dfn> is an optional method that asynchronously returns a <code>void</code>.
-      <dfn>query</dfn> is a query string that SHOULD be a SPARQL update query.
+      <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL update query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
   </section>
 
+</section>
+
+<section>
+  <h2>Query context interfaces</h2>
+  
+  This section introduces interfaces related to query contexts,
+  which are an optional argument to queryable interfaces for passing additional in information to query engines.
+  
+  <section data-dfn-for="QueryContext">
+    <h3><dfn>QueryContext</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryContext {
+      attribute Date? queryTimestamp;
+    };
+    </pre>
+    
+    <p>
+      <code>QueryContext</code> is a base context interface.
+    </p>
+    
+    <p>
+      <dfn>queryTimestamp</dfn> The date that should be used by SPARQL operations such as <code>NOW()</code>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryStringContext">
+    <h3><dfn>QueryStringContext</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryStringContext : QueryContext {
+      attribute QueryFormat? queryFormat;
+      attribute string? baseIRI;
+    };
+    </pre>
+    
+    <p>
+      A <code>QueryStringContext</code> is a context that can be passed together with a query string.
+    </p>
+    
+    <p>
+      <dfn>queryFormat</dfn> The format in which the query string is defined.
+    </p>
+    <p>
+      <dfn>baseIRI</dfn> The base IRI for parsing the query.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryAlgebraContext">
+    <h3><dfn>QueryAlgebraContext</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryAlgebraContext : QueryContext {};
+    </pre>
+    
+    <p>
+      A <code>QueryAlgebraContext</code> is a context that can be passed together with a query <code>Algebra</code> object.
+    </p>
+    
+  </section>
+  
+  <section data-dfn-for="QuerySourceContext">
+    <h3><dfn>QuerySourceContext</dfn> interface</h3>
+    <pre class="idl">
+    interface QuerySourceContext : QueryContext {
+      attribute Array? sources;
+    };
+    </pre>
+    
+    <p>
+      A <code>QuerySourceContext</code> can be used by query engines that accept custom data sources during query execution.
+    </p>
+    
+    <p>
+      <dfn>sources</dfn> An array of data sources the query engine must use.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryFormat">
+    <h3><dfn>QueryFormat</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryFormat {
+      attribute string language;
+      attribute string version;
+      attribute Array&lt;string&gt;? extensions;
+    };
+    </pre>
+    
+    <p>
+      A <code>QueryFormat</code> represents the format of a string query, and may influence parsing or execution behaviour.
+    </p>
+    
+    <p>
+      <dfn>language</dfn> The query language, e.g. <code>"sparql"</code>.
+    </p>
+    <p>
+      <dfn>version</dfn> The version of the query language, e.g. <code>"1.1"</code>.
+    </p>
+    <p>
+      <dfn>language</dfn> An optional array of extensions on the query language. The representation of these extensions is undefined.
+    </p>
+  </section>
+  
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -101,6 +101,165 @@
 </section>
 
 <section>
+  <h2>Bindings interfaces</h2>
+  
+  This section introduces interfaces related to query result bindings.
+  In SPARQL SELECT queries, these bindings correspond to <a href="https://www.w3.org/TR/sparql11-query/#sparqlSolutions">solution mappings</a>.
+
+  <section>
+    <h2>Goals</h2>
+    <ul>
+      <li>Query engines should be able to interact with bindings created by different libraries.</li>
+      <li>Bindings are immutable</li>
+      <li>Interfaces do no specify how bindings are stored in memory</li>
+    </ul>
+  </section>
+  
+  <section data-dfn-for="Bindings">
+    <h3><dfn>Bindings</dfn> interface</h3>
+
+    <pre class="idl">
+    interface Bindings {
+      iterable&lt;(Variable, Term)&gt;;
+
+      readonly attribute string type;
+      readonly attribute unsigned long size;
+
+      boolean has((Variable or string) key);
+      Term? get((Variable or string) key);
+      Bindings set((Variable or string) key, Term value);
+      Bindings delete((Variable or string) key);
+      iterable&lt;Variable&gt; keys();
+      iterable&lt;Term&gt; values();
+      boolean equals(optional Bindings? other);
+      void forEach(BindingsEntryCallback callback);
+      Bindings filter(BindingsFilterCallback callback);
+      Bindings map(BindingsMapCallback callback);
+      Bindings merge(Bindings other);
+      Bindings mergeWith(BindingsMergeCallback callback, Bindings other);
+    };
+    
+    callback BindingsEntryCallback = undefined (Term value, Variable key);
+    callback BindingsFilterCallback = boolean (Term value, Variable key);
+    callback BindingsMapCallback = Term (Term value, Variable key);
+    callback BindingsMergeCallback = Term (Term self, Term other, Variable key);
+    </pre>
+
+    <p>
+      A <code>Bindings</code> is an object that represents the mapping of variables to RDF values using an immutable Map-like representation.
+      This means that methods such as <code>set</code> and <code>delete</code> do not modify this instance,
+      but they return a new Bindings instance that contains the modification.
+    </p>
+    <p>
+      Every <code>Bindings</code> object is an iterable over its entries, where each entry is a tuple of <code>Variable</code> key and <code>Term</code> value.
+    </p>
+    
+    <h3>Attributes</h3>
+    
+    <p>
+      <dfn>type</dfn> contains the constant <code>"bindings"</code>.
+    </p>
+    <p>
+      <dfn>size</dfn> is a field that contains the number of entries in this <code>Bindings</code> object.
+    </p>
+    
+    <h3>Methods</h3>
+    
+    <p>
+      <dfn>has</dfn> checks if a binding exist for the given variable.
+      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+    </p>
+    <p>
+      <dfn>get</dfn> returns the <code>Term</code> value bound to the given variable, or <code>undefined</code> if no binding exists.
+      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+    </p>
+    <p>
+      <dfn>set</dfn> returns a new <code>Bindings</code> object by adding the given variable and value mapping.
+      If the variable already exists in the binding, then the existing mapping is overwritten.
+      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+      <dfn>value</dfn> is the <code>Term</code> value that must be bound.
+    </p>
+    <p>
+      <dfn>delete</dfn> returns a new <code>Bindings</code> object by removing the given variable.
+      If the variable does not exist in the binding, a copy of the <code>Bindings</code> object is returned.
+      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+    </p>
+    <p>
+      <dfn>keys</dfn> returns an iterable of <code>Variable</code> instances for which mappings exist.
+    </p>
+    <p>
+      <dfn>values</dfn> returns an iterable of <code>Term</code> values for which mappings exist.
+    </p>
+    <p>
+      <dfn>equals</dfn> returns <code>true</code>
+      when called with parameter <code>other</code>
+      on an object <code>Bindings</code> if
+      all of the conditions below hold:
+    </p>
+    <ul>
+      <li><code>other</code> is <em>neither</em> <code>null</code> nor <code>undefined</code>;</li>
+      <li>The keys in the this and the other <code>Bindings</code> object are equal (following the semantics of <code>Variable.equals</code>);</li>
+      <li>For each key, the values within each <code>Bindings</code> object are equal (following the semantics of <code>Term.equals</code>);</li>
+    </ul>
+    <p>
+      <dfn>forEach</dfn> invokes the <code>callback</code> for all entries in this <code>Bindings</code> object,
+      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
+    </p>
+    <p>
+      <dfn>filter</dfn> returns a new <code>Bindings</code> object by filtering entries using <code>callback</code>,
+      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
+      Returning <code>true</code> indicates that this entry must be contained in the resulting <code>Bindings</code> object.
+    </p>
+    <p>
+      <dfn>map</dfn> returns a new <code>Bindings</code> object by mapping entries using <code>callback</code>,
+      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
+      The original <code>Term</code> value is replaced by the returned <code>Term</code> value in the resulting <code>Bindings</code> object.
+    </p>
+    <p>
+      <dfn>merge</dfn> merges this <code>Bindings</code> object with another <code>Bindings</code> object.
+      If a merge conflict occurs (this and other have an equal variable with unequal value), then <code>undefined</code> is returned.
+    </p>
+    <p>
+      <dfn>mergeWith</dfn> merges this <code>Bindings</code> object with another <code>Bindings</code> object,
+      where merge conflicts can be resolved using <code>callback</code>.
+      <code>callback</code> is invoked with the value <code>Term</code> of the first <code>Bindings</code> object as first argument,
+      the value <code>Term</code> of the second <code>Bindings</code> object as second argument,
+      and the key <code>Variable</code> as third argument,
+      where the returned <code>Term</code> is considered the merged value.
+    </p>
+  </section>
+
+  <section data-dfn-for="BindingsFactory">
+    <h3><dfn>BindingsFactory</dfn> interface</h3>
+
+    <pre class="idl">
+    interface BindingsFactory {
+      Bindings bindings(Array&lt;(Variable, Term)&gt;? entries);
+      Bindings fromBindings(Bindings bindings);
+    };
+    </pre>
+
+    <p>
+      <dfn>bindings()</dfn> returns a new <code>Bindings</code> using the given entries,
+      where the entries are represented as an array of key-value pairs.
+    </p>    
+    <p>
+      <dfn>fromBindings()</dfn> returns a copy of the given <code>Bindings</code> using this factory.
+    </p>
+  </section>
+
+</section>
+
+  <div class="warning" title="Experimental!">
+    <p>
+      The following interfaces are experimental and will change in future versions of this document:
+    </p>
+    <p>
+      <code>FilterableSource</code>, <code>FilterResult</code>, <code>QueryResultMetadata</code>, <code>QueryResultMetadataCount</code>, <code>QueryResultMetadataOptions</code>, <code>Expression</code>, <code>OperatorExpression</code>, <code>TermExpression</code>, <code>ExpressionFactory</code>
+    </p>
+  </div>
+
+<section>
   <h2>Filter expression interfaces</h2>
   
   This section introduces interfaces that enable quad sources to be filtered based on a declarative expression.

--- a/index.html
+++ b/index.html
@@ -101,51 +101,6 @@
 </section>
 
 <section>
-  <h2>Queryable interfaces</h2>
-  
-  This section introduces interfaces that can be implemented by query engines to make them expose a query execution interface.
-
-  <section data-dfn-for="StringQueryable">
-    <h3><dfn>StringQueryable</dfn> interface</h3>
-
-    <pre class="idl">
-    interface StringQueryable {
-      Promise&lt;Query&gt; query(String query, QueryStringContext? context);
-    };
-    </pre>
-
-    <p>
-      A <code>StringQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as a string.
-    </p>
-    <p>
-      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
-      <dfn>query</dfn> is a query string.
-      <dfn>context</dfn> is an optional context in which query execution options can be passed.
-    </p>
-  </section>
-  
-  <section data-dfn-for="AlgebraQueryable">
-    <h3><dfn>AlgebraQueryable</dfn> interface</h3>
-
-    <pre class="idl">
-    interface AlgebraQueryable {
-      Promise&lt;Query&gt; query(Algebra query, QueryAlgebraContext? context);
-    };
-    </pre>
-
-    <p>
-      An <code>AlgebraQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
-    </p>
-    <p>
-      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
-      <dfn>query</dfn> is a query <code>Algebra</code> object.
-      <dfn>context</dfn> is an optional context in which query execution options can be passed.
-    </p>
-  </section>
-
-</section>
-
-<section>
   <h2>SPARQL Queryable interfaces</h2>
   
   This section introduces queryable interfaces that can be implemented by SPARQL-constrained query engines.
@@ -227,6 +182,215 @@
     </p>
   </section>
 
+</section>
+
+<section>
+  <h2>Queryable interfaces</h2>
+  
+  This section introduces interfaces that can be implemented by query engines to make them expose a query execution interface.
+
+  <section data-dfn-for="StringQueryable">
+    <h3><dfn>StringQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface StringQueryable {
+      Promise&lt;Query&gt; query(String query, QueryStringContext? context);
+    };
+    </pre>
+
+    <p>
+      A <code>StringQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as a string.
+    </p>
+    <p>
+      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query</dfn> is a query string.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+  
+  <section data-dfn-for="AlgebraQueryable">
+    <h3><dfn>AlgebraQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface AlgebraQueryable {
+      Promise&lt;Query&gt; query(Algebra query, QueryAlgebraContext? context);
+    };
+    </pre>
+
+    <p>
+      An <code>AlgebraQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
+    </p>
+    <p>
+      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query</dfn> is a query <code>Algebra</code> object.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+
+</section>
+
+<section>
+  <h2>Query interfaces</h2>
+  
+  This section introduces query interfaces that act as intermediary objects that represent queries that can be executed.
+  
+  <section data-dfn-for="Query">
+    <h3><dfn>Query</dfn> interface</h3>
+    <pre class="idl">
+    interface Query {
+      readonly attribute string resultType;
+      Promise&lt;any&gt; execute(any options);
+    };
+    </pre>
+
+    <p>
+      <code>Query</code> is an abstract interface that represents a query that can be executed.
+    </p>
+
+    <p>
+      <dfn>resultType</dfn> represents the type of query that is being executed.
+      Possible values include <code>"bindings"</code>, <code>"quads"</code>, <code>"boolean"</code>, and <code>"void"</code>.
+    </p>
+    <p>
+      <dfn>execute()</dfn> asynchronously returns the query result, where the signature depends on the <code>resultType</code>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryBindings">
+    <h3><dfn>QueryBindings</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryBindings {
+      readonly attribute string resultType;
+      Promise&lt;Stream&lt;Bindings&gt;&gt; execute(QueryExecuteOptions&lt;Variable&gt;? options);
+      Promise&lt;QueryMetadata&lt;Bindings&gt;&gt; metadata(QueryMetadataOptions? options);
+    };
+    </pre>
+
+    <p>
+      <code>QueryBindings</code> represents a query that returns a stream of <code>Bindings</code>, such as a SPARQL <code>SELECT</code> query.
+    </p>
+
+    <p>
+      <dfn>resultType</dfn> contains the constant <code>"bindings"</code>.
+    </p>
+    <p>
+      <dfn>execute()</dfn> asynchronously returns the a stream of <code>Bindings</code>.
+      <dfn>options</dfn> is an optional argument in which execution options can be passed.
+    </p>
+    <p>
+      <dfn>metadata()</dfn> asynchronously returns the a <code>QueryMetadata</code> object.
+      <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryQuads">
+    <h3><dfn>QueryQuads</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryQuads {
+      readonly attribute string resultType;
+      Promise&lt;Stream&lt;Quad&gt;&gt; execute(QueryExecuteOptions&lt;("subject" or "predicate" or "object" or "graph")&gt;? options);
+      Promise&lt;QueryMetadata&lt;Quad&gt;&gt; metadata(QueryMetadataOptions? options);
+    };
+    </pre>
+
+    <p>
+      <code>QueryQuads</code> represents a query that returns a stream of <code>Quad</code>s, such as a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
+    </p>
+
+    <p>
+      <dfn>resultType</dfn> contains the constant <code>"quads"</code>.
+    </p>
+    <p>
+      <dfn>execute()</dfn> asynchronously returns the a stream of <code>Quad</code>s.
+      <dfn>options</dfn> is an optional argument in which execution options can be passed.
+    </p>
+    <p>
+      <dfn>metadata()</dfn> asynchronously returns the a <code>QueryMetadata</code> object.
+      <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryBoolean">
+    <h3><dfn>QueryBoolean</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryBoolean {
+      readonly attribute string resultType;
+      Promise&lt;boolean&gt; execute();
+    };
+    </pre>
+
+    <p>
+      <code>QueryBoolean</code> represents a query that returns a <code>boolean</code>, such as a SPARQL <code>ASK</code> query.
+    </p>
+
+    <p>
+      <dfn>resultType</dfn> contains the constant <code>"boolean"</code>.
+    </p>
+    <p>
+      <dfn>execute()</dfn> asynchronously returns a <code>boolean</code>.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryVoid">
+    <h3><dfn>QueryVoid</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryVoid {
+      readonly attribute string resultType;
+      Promise&lt;void&gt; execute();
+    };
+    </pre>
+
+    <p>
+      <code>QueryVoid</code> represents a query that returns nothing, such as a SPARQL update query.
+    </p>
+
+    <p>
+      <dfn>resultType</dfn> contains the constant <code>"void"</code>.
+    </p>
+    <p>
+      <dfn>execute()</dfn> asynchronously returns nothing.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryExecuteOptions">
+    <h3><dfn>QueryExecuteOptions</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryExecuteOptions&lt;OrderType&gt; {
+      readonly attribute Array&lt;QueryOperationOrderTerm&lt;OrderType&gt;&gt; order;
+    };
+    </pre>
+
+    <p>
+      <code>QueryExecuteOptions</code> represents the options for executing a query.
+    </p>
+
+    <p>
+      <dfn>order</dfn> contains the desired order of query results.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryOperationOrderTerm">
+    <h3><dfn>QueryOperationOrderTerm</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryOperationOrderTerm&lt;OrderType&gt; {
+      attribute OrderType term;
+      attribute ("asc" or "desc") direction;
+    };
+    </pre>
+
+    <p>
+      <code>QueryOperationOrderTerm</code> represents the ordering of a term of a given generic type.
+    </p>
+
+    <p>
+      <dfn>term</dfn> contains the term over which the order is applied.
+    </p>
+    <p>
+      <dfn>direction</dfn> contains the value <code>"asc"</code> or <code>"desc"</code>,
+      which respectively refer to an ascending or descending order.
+    </p>
+  </section>
+  
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -121,12 +121,12 @@
       that accepts queries as a string.
     </p>
     <p>
-      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Bindings</code> objects.
+      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <a href="https://rdf.js.org/stream-spec/#stream-interface">Stream</a> of <a>Bindings</a> objects.
       <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>SELECT</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
     <p>
-      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Quad</code> objects.
+      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <a href="https://rdf.js.org/stream-spec/#stream-interface">Stream</a> of <a href="http://rdf.js.org/data-model-spec/#quad-interface">Quad</a> objects.
       <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
@@ -158,12 +158,12 @@
       An <code>AlgebraSparqlQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
     </p>
     <p>
-      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Bindings</code> objects.
+      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <a href="https://rdf.js.org/stream-spec/#stream-interface">Stream</a> of <a>Bindings</a> objects.
       <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL <code>SELECT</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
     <p>
-      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Quad</code> objects.
+      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <a href="https://rdf.js.org/stream-spec/#stream-interface">Stream</a> of <a href="http://rdf.js.org/data-model-spec/#quad-interface">Quad</a> objects.
       <dfn>query</dfn> is a query <code>Algebra</code> object that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
@@ -199,7 +199,7 @@
       A <code>StringQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as a string.
     </p>
     <p>
-      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query()</dfn> asynchronously returns a new <a>Query</a> object that can be executed later.
       <dfn>query</dfn> is a query string.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
@@ -218,7 +218,7 @@
       An <code>AlgebraQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
     </p>
     <p>
-      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query()</dfn> asynchronously returns a new <a>Query</a> object that can be executed later.
       <dfn>query</dfn> is a query <code>Algebra</code> object.
       <dfn>context</dfn> is an optional context in which query execution options can be passed.
     </p>
@@ -264,18 +264,18 @@
     </pre>
 
     <p>
-      <code>QueryBindings</code> represents a query that returns a stream of <code>Bindings</code>, such as a SPARQL <code>SELECT</code> query.
+      <code>QueryBindings</code> represents a query that returns a stream of <a>Bindings</a>, such as a SPARQL <code>SELECT</code> query.
     </p>
 
     <p>
       <dfn>resultType</dfn> contains the constant <code>"bindings"</code>.
     </p>
     <p>
-      <dfn>execute()</dfn> asynchronously returns a stream of <code>Bindings</code>.
+      <dfn>execute()</dfn> asynchronously returns a stream of <a>Bindings</a>.
       <dfn>options</dfn> is an optional argument in which execution options can be passed.
     </p>
     <p>
-      <dfn>metadata()</dfn> asynchronously returns a <code>QueryMetadata</code> object.
+      <dfn>metadata()</dfn> asynchronously returns a <a>QueryMetadata</a> object.
       <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
     </p>
   </section>
@@ -291,18 +291,18 @@
     </pre>
 
     <p>
-      <code>QueryQuads</code> represents a query that returns a stream of <code>Quad</code>s, such as a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
+      <code>QueryQuads</code> represents a query that returns a stream of <a href="http://rdf.js.org/data-model-spec/#quad-interface">Quad</a>s, such as a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
     </p>
 
     <p>
       <dfn>resultType</dfn> contains the constant <code>"quads"</code>.
     </p>
     <p>
-      <dfn>execute()</dfn> asynchronously returns a stream of <code>Quad</code>s.
+      <dfn>execute()</dfn> asynchronously returns a stream of <a href="http://rdf.js.org/data-model-spec/#quad-interface">Quad</a>s.
       <dfn>options</dfn> is an optional argument in which execution options can be passed.
     </p>
     <p>
-      <dfn>metadata()</dfn> asynchronously returns a <code>QueryMetadata</code> object.
+      <dfn>metadata()</dfn> asynchronously returns a <a>QueryMetadata</a> object.
       <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
     </p>
   </section>
@@ -664,12 +664,12 @@
     </pre>
 
     <p>
-      A <code>Bindings</code> is an object that represents the mapping of variables to RDF values using an immutable Map-like representation.
+      A <a>Bindings</a> is an object that represents the mapping of variables to RDF values using an immutable Map-like representation.
       This means that methods such as <code>set</code> and <code>delete</code> do not modify this instance,
       but they return a new Bindings instance that contains the modification.
     </p>
     <p>
-      Every <code>Bindings</code> object is an iterable over its entries, where each entry is a tuple of <code>Variable</code> key and <code>Term</code> value.
+      Every <a>Bindings</a> object is an iterable over its entries, where each entry is a tuple of <code>Variable</code> key and <code>Term</code> value.
     </p>
     
     <h3>Attributes</h3>
@@ -678,72 +678,72 @@
       <dfn>type</dfn> contains the constant <code>"bindings"</code>.
     </p>
     <p>
-      <dfn>size</dfn> is a field that contains the number of entries in this <code>Bindings</code> object.
+      <dfn>size</dfn> is a field that contains the number of entries in this <a>Bindings</a> object.
     </p>
     
     <h3>Methods</h3>
     
     <p>
       <dfn>has</dfn> checks if a binding exist for the given variable.
-      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+      <dfn>key</dfn> can be a <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> or string. If it is a string, no `?` prefix must be given.
     </p>
     <p>
-      <dfn>get</dfn> returns the <code>Term</code> value bound to the given variable, or <code>undefined</code> if no binding exists.
-      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+      <dfn>get</dfn> returns the <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> value bound to the given variable, or <code>undefined</code> if no binding exists.
+      <dfn>key</dfn> can be a <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> or string. If it is a string, no `?` prefix must be given.
     </p>
     <p>
-      <dfn>set</dfn> returns a new <code>Bindings</code> object by adding the given variable and value mapping.
+      <dfn>set</dfn> returns a new <a>Bindings</a> object by adding the given variable and value mapping.
       If the variable already exists in the binding, then the existing mapping is overwritten.
-      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
-      <dfn>value</dfn> is the <code>Term</code> value that must be bound.
+      <dfn>key</dfn> can be a <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> or string. If it is a string, no `?` prefix must be given.
+      <dfn>value</dfn> is the <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> value that must be bound.
     </p>
     <p>
-      <dfn>delete</dfn> returns a new <code>Bindings</code> object by removing the given variable.
-      If the variable does not exist in the binding, a copy of the <code>Bindings</code> object is returned.
-      <dfn>key</dfn> can be a <code>Variable</code> or string. If it is a string, no `?` prefix must be given.
+      <dfn>delete</dfn> returns a new <a>Bindings</a> object by removing the given variable.
+      If the variable does not exist in the binding, a copy of the <a>Bindings</a> object is returned.
+      <dfn>key</dfn> can be a <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> or string. If it is a string, no `?` prefix must be given.
     </p>
     <p>
-      <dfn>keys</dfn> returns an iterable of <code>Variable</code> instances for which mappings exist.
+      <dfn>keys</dfn> returns an iterable of <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> instances for which mappings exist.
     </p>
     <p>
-      <dfn>values</dfn> returns an iterable of <code>Term</code> values for which mappings exist.
+      <dfn>values</dfn> returns an iterable of <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> values for which mappings exist.
     </p>
     <p>
       <dfn>equals</dfn> returns <code>true</code>
       when called with parameter <code>other</code>
-      on an object <code>Bindings</code> if
+      on an object <a>Bindings</a> if
       all of the conditions below hold:
     </p>
     <ul>
       <li><code>other</code> is <em>neither</em> <code>null</code> nor <code>undefined</code>;</li>
-      <li>The keys in the this and the other <code>Bindings</code> object are equal (following the semantics of <code>Variable.equals</code>);</li>
-      <li>For each key, the values within each <code>Bindings</code> object are equal (following the semantics of <code>Term.equals</code>);</li>
+      <li>The keys in the this and the other <a>Bindings</a> object are equal (following the semantics of <code>Variable.equals</code>);</li>
+      <li>For each key, the values within each <a>Bindings</a> object are equal (following the semantics of <code>Term.equals</code>);</li>
     </ul>
     <p>
-      <dfn>forEach</dfn> invokes the <code>callback</code> for all entries in this <code>Bindings</code> object,
-      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
+      <dfn>forEach</dfn> invokes the <code>callback</code> for all entries in this <a>Bindings</a> object,
+      with the entry value <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> as first argument, and the entry key <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> as second argument.
     </p>
     <p>
-      <dfn>filter</dfn> returns a new <code>Bindings</code> object by filtering entries using <code>callback</code>,
-      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
-      Returning <code>true</code> indicates that this entry must be contained in the resulting <code>Bindings</code> object.
+      <dfn>filter</dfn> returns a new <a>Bindings</a> object by filtering entries using <code>callback</code>,
+      with the entry value <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> as first argument, and the entry key <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> as second argument.
+      Returning <code>true</code> indicates that this entry must be contained in the resulting <a>Bindings</a> object.
     </p>
     <p>
-      <dfn>map</dfn> returns a new <code>Bindings</code> object by mapping entries using <code>callback</code>,
-      with the entry value <code>Term</code> as first argument, and the entry key <code>Variable</code> as second argument.
-      The original <code>Term</code> value is replaced by the returned <code>Term</code> value in the resulting <code>Bindings</code> object.
+      <dfn>map</dfn> returns a new <a>Bindings</a> object by mapping entries using <code>callback</code>,
+      with the entry value <code>Term</code> as first argument, and the entry key <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> as second argument.
+      The original <code>Term</code> value is replaced by the returned <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> value in the resulting <a>Bindings</a> object.
     </p>
     <p>
-      <dfn>merge</dfn> merges this <code>Bindings</code> object with another <code>Bindings</code> object.
+      <dfn>merge</dfn> merges this <a>Bindings</a> object with another <a>Bindings</a> object.
       If a merge conflict occurs (this and other have an equal variable with unequal value), then <code>undefined</code> is returned.
     </p>
     <p>
-      <dfn>mergeWith</dfn> merges this <code>Bindings</code> object with another <code>Bindings</code> object,
+      <dfn>mergeWith</dfn> merges this <a>Bindings</a> object with another <a>Bindings</a> object,
       where merge conflicts can be resolved using <code>callback</code>.
-      <code>callback</code> is invoked with the value <code>Term</code> of the first <code>Bindings</code> object as first argument,
-      the value <code>Term</code> of the second <code>Bindings</code> object as second argument,
-      and the key <code>Variable</code> as third argument,
-      where the returned <code>Term</code> is considered the merged value.
+      <code>callback</code> is invoked with the value <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> of the first <a>Bindings</a> object as first argument,
+      the value <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> of the second <a>Bindings</a> object as second argument,
+      and the key <a href="http://rdf.js.org/data-model-spec/#variable-interface">Variable</a> as third argument,
+      where the returned <a href="http://rdf.js.org/data-model-spec/#term-interface">Term</a> is considered the merged value.
     </p>
   </section>
 
@@ -758,11 +758,11 @@
     </pre>
 
     <p>
-      <dfn>bindings()</dfn> returns a new <code>Bindings</code> using the given entries,
+      <dfn>bindings()</dfn> returns a new <a>Bindings</a> using the given entries,
       where the entries are represented as an array of key-value pairs.
     </p>    
     <p>
-      <dfn>fromBindings()</dfn> returns a copy of the given <code>Bindings</code> using this factory.
+      <dfn>fromBindings()</dfn> returns a copy of the given <a>Bindings</a> using this factory.
     </p>
   </section>
 

--- a/index.html
+++ b/index.html
@@ -271,11 +271,11 @@
       <dfn>resultType</dfn> contains the constant <code>"bindings"</code>.
     </p>
     <p>
-      <dfn>execute()</dfn> asynchronously returns the a stream of <code>Bindings</code>.
+      <dfn>execute()</dfn> asynchronously returns a stream of <code>Bindings</code>.
       <dfn>options</dfn> is an optional argument in which execution options can be passed.
     </p>
     <p>
-      <dfn>metadata()</dfn> asynchronously returns the a <code>QueryMetadata</code> object.
+      <dfn>metadata()</dfn> asynchronously returns a <code>QueryMetadata</code> object.
       <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
     </p>
   </section>
@@ -298,11 +298,11 @@
       <dfn>resultType</dfn> contains the constant <code>"quads"</code>.
     </p>
     <p>
-      <dfn>execute()</dfn> asynchronously returns the a stream of <code>Quad</code>s.
+      <dfn>execute()</dfn> asynchronously returns a stream of <code>Quad</code>s.
       <dfn>options</dfn> is an optional argument in which execution options can be passed.
     </p>
     <p>
-      <dfn>metadata()</dfn> asynchronously returns the a <code>QueryMetadata</code> object.
+      <dfn>metadata()</dfn> asynchronously returns a <code>QueryMetadata</code> object.
       <dfn>options</dfn> is an optional argument in which desired metadata options can be passed.
     </p>
   </section>

--- a/index.html
+++ b/index.html
@@ -369,6 +369,85 @@
     </p>
   </section>
   
+  <section data-dfn-for="QueryMetadataOptions">
+    <h3><dfn>QueryMetadataOptions</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryMetadataOptions {
+      attribute ("estimate" or "exact")? cardinality;
+      attribute boolean order;
+      attribute boolean availableOrders;
+    };
+    </pre>
+
+    <p>
+      <code>QueryMetadataOptions</code> represents the options for requesting the metadata of a query.
+    </p>
+
+    <p>
+      <dfn>cardinality</dfn> indicates if an exact or estimated value for the <code>cardinality</code> metadata field should be returned.
+    </p>
+    <p>
+      <dfn>order</dfn> indicates if the <code>order</code> metadata field should be returned.
+    </p>
+    <p>
+      <dfn>availableOrders</dfn> indicates if the <code>availableOrders</code> metadata field should be returned.
+    </p>
+  </section>
+  
+</section>
+
+<section>
+  <h2>Metadata interfaces</h2>
+  
+  This section introduces metadata interfaces that can contain additional information about the query execution process.
+  
+  <section data-dfn-for="QueryMetadata">
+    <h3><dfn>QueryMetadata</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryMetadata&lt;OrderType&gt; {
+      readonly attribute QueryResultCardinality? cardinality;
+      readonly attribute Array&lt;QueryOperationOrderTerm&lt;OrderType&gt;&gt;? order;
+      readonly attribute Array&lt;QueryResultOrderCost&lt;OrderType&gt;&gt;? availableOrders;
+    };
+    </pre>
+
+    <p>
+      <code>QueryMetadata</code> is an interface that contains side information about the query execution process.
+    </p>
+
+    <p>
+      <dfn>cardinality</dfn> represents the number of results of a query.
+    </p>
+    <p>
+      <dfn>order</dfn> represents the order of results in the query result.
+    </p>
+    <p>
+      <dfn>availableOrders</dfn> is an array of alternative orders that may be requested when executing a query.
+    </p>
+  </section>
+  
+  <section data-dfn-for="QueryResultCardinality">
+    <h3><dfn>QueryResultCardinality</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryResultCardinality {
+      attribute ("estimate" or "exact") type;
+      attribute unsigned long value;
+    };
+    </pre>
+
+    <p>
+      <code>QueryResultCardinality</code> represents the number of results of a query, which can either be an estimated value or exact.
+    </p>
+
+    <p>
+      <dfn>type</dfn> contains the value <code>"estimate"</code> or <code>"exact"</code>,
+      which respectively refer to an exact or estimate value.
+    </p>
+    <p>
+      <dfn>value</dfn> contains the cardinality value.
+    </p>
+  </section>
+
   <section data-dfn-for="QueryOperationOrderTerm">
     <h3><dfn>QueryOperationOrderTerm</dfn> interface</h3>
     <pre class="idl">
@@ -390,7 +469,56 @@
       which respectively refer to an ascending or descending order.
     </p>
   </section>
-  
+
+  <section data-dfn-for="QueryResultOrderCost">
+    <h3><dfn>QueryResultOrderCost</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryResultOrderCost&lt;OrderType&gt; {
+      attribute QueryOperationCost cost;
+      attribute Array&lt;QueryOperationOrderTerm&lt;OrderType&gt;&gt; terms;
+    };
+    </pre>
+
+    <p>
+      <code>QueryResultOrderCost</code> represents the cost of a specific ordering of query results.
+    </p>
+
+    <p>
+      <dfn>cost</dfn> represents the cost of executing this ordering.
+    </p>
+    <p>
+      <dfn>terms</dfn> represents the order of terms in an ordering.
+    </p>
+  </section>
+
+  <section data-dfn-for="QueryOperationCost">
+    <h3><dfn>QueryOperationCost</dfn> interface</h3>
+    <pre class="idl">
+    interface QueryOperationCost {
+      attribute unsigned long iterations;
+      attribute unsigned long persistedItems;
+      attribute unsigned long blockingItems;
+      attribute unsigned long requestTime;
+    };
+    </pre>
+
+    <p>
+      <code>QueryOperationCost</code> represents the cost of a certain query operation.
+    </p>
+
+    <p>
+      <dfn>iterations</dfn> is estimation of how many iterations over items are executed. This can be used to determine the CPU cost.
+    </p>
+    <p>
+      <dfn>persistedItems</dfn> is estimation of how many items are stored in memory. This is used to determine the memory cost.
+    </p>
+    <p>
+      <dfn>blockingItems</dfn> is estimation of how many items block the stream. This is used to determine the time the stream is not progressing anymore.
+    </p>
+    <p>
+      <dfn>requestTime</dfn> is estimation of the time to request items from sources. This is used to determine the I/O cost.
+    </p>
+  </section>
 </section>
 
 <section>

--- a/index.html
+++ b/index.html
@@ -101,6 +101,135 @@
 </section>
 
 <section>
+  <h2>Queryable interfaces</h2>
+  
+  This section introduces interfaces that can be implemented by query engines to make them expose a query execution interface.
+
+  <section data-dfn-for="StringQueryable">
+    <h3><dfn>StringQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface StringQueryable {
+      Promise&lt;Query&gt; query(String query, QueryStringContext? context);
+    };
+    </pre>
+
+    <p>
+      A <code>StringQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as a string.
+    </p>
+    <p>
+      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query</dfn> is a query string.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+  
+  <section data-dfn-for="AlgebraQueryable">
+    <h3><dfn>AlgebraQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface AlgebraQueryable {
+      Promise&lt;Query&gt; query(Algebra query, QueryAlgebraContext? context);
+    };
+    </pre>
+
+    <p>
+      An <code>AlgebraQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
+    </p>
+    <p>
+      <dfn>query()</dfn> asynchronously returns a new <code>Query</code> object that can be executed later.
+      <dfn>query</dfn> is a query <code>Algebra</code> object.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+
+</section>
+
+<section>
+  <h2>SPARQL Queryable interfaces</h2>
+  
+  This section introduces queryable interfaces that can be implemented by SPARQL-constrained query engines.
+  These interfaces guarantees that result objects are of the expected type as defined by the SPARQL spec,
+  and is often more convenient to use compared to the general queryable interfaces.
+
+  <section data-dfn-for="StringSparqlQueryable">
+    <h3><dfn>StringSparqlQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface StringSparqlQueryable {
+      optional Promise&lt;Stream&lt;Bindings&gt;&gt; queryBindings(String query, QueryStringContext? context);
+      optional Promise&lt;Stream&lt;Quad&gt;&gt; queryQuads(String query, QueryStringContext? context);
+      optional Promise&lt;boolean&gt; queryBoolean(String query, QueryStringContext? context);
+      optional Promise&lt;void&gt; queryVoid(String query, QueryStringContext? context);
+    };
+    </pre>
+
+    <p>
+      A <code>StringSparqlQueryable</code> can be implemented by objects that want to expose a SPARQL-constrained query execution interface
+      that accepts queries as a string.
+    </p>
+    <p>
+      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Bindings</code> objects.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>SELECT</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Quad</code> objects.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryBoolean()</dfn> is an optional method that asynchronously returns a <code>boolean</code>.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>ASK</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryVoid()</dfn> is an optional method that asynchronously returns a <code>void</code>.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL update query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+  
+  <section data-dfn-for="AlgebraSparqlQueryable">
+    <h3><dfn>AlgebraSparqlQueryable</dfn> interface</h3>
+
+    <pre class="idl">
+    interface AlgebraSparqlQueryable {
+      optional Promise&lt;Stream&lt;Bindings&gt;&gt; queryBindings(Algebra query, QueryStringContext? context);
+      optional Promise&lt;Stream&lt;Quad&gt;&gt; queryQuads(Algebra query, QueryStringContext? context);
+      optional Promise&lt;boolean&gt; queryBoolean(Algebra query, QueryStringContext? context);
+      optional Promise&lt;void&gt; queryVoid(Algebra query, QueryStringContext? context);
+    };
+    </pre>
+
+    <p>
+      An <code>AlgebraSparqlQueryable</code> can be implemented by objects that want to expose a query execution interface that accepts queries as an <code>Algebra</code> object.
+    </p>
+    <p>
+      <dfn>queryBindings()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Bindings</code> objects.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>SELECT</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryQuads()</dfn> is an optional method that asynchronously returns a <code>Stream</code> of <code>Quad</code> objects.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>CONSTRUCT</code> or <code>DESCRIBE</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryBoolean()</dfn> is an optional method that asynchronously returns a <code>boolean</code>.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL <code>ASK</code> query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+    <p>
+      <dfn>queryVoid()</dfn> is an optional method that asynchronously returns a <code>void</code>.
+      <dfn>query</dfn> is a query string that SHOULD be a SPARQL update query.
+      <dfn>context</dfn> is an optional context in which query execution options can be passed.
+    </p>
+  </section>
+
+</section>
+
+<section>
   <h2>Bindings interfaces</h2>
   
   This section introduces interfaces related to query result bindings.

--- a/index.html
+++ b/index.html
@@ -68,13 +68,10 @@
 <section id="abstract">
   <h2>Abstract</h2>
   <p>
-    The scope of this specification is to provide a way to query over quads, as defined in the <a href="http://rdf.js.org/data-model-spec/#quad-interface">RDF/JS: Data model specification</a>.
-    Similar to the <a href="http://rdf.js.org/data-model-spec/">RDF/JS: Data model specification</a>, this is a low-level specification that provides only essential methods for working across query engine component.
-    High-level querying interfaces can and should be using libraries that implement this interface.
+    The scope of this specification is to provide a way to query over RDF quads in JavaScript, as defined in the <a href="http://rdf.js.org/data-model-spec/#quad-interface">RDF/JS: Data model specification</a>.
+    It contains high-level interfaces for libraries that want to expose querying capabilities,
+    and low-level interfaces for working across query engine components.
   </p>
-  <p>The specification itself consists of a core-part that is the base for all other functions defined.</p>
-  <p>Low-level methods are using explicit parameters that cannot be omitted.</p>
-  <p>Additional high-level interfaces are outside of the scope of this specification and should be defined elsewhere.</p>
 </section>
 
 <section id="sotd">
@@ -85,8 +82,8 @@
     interface to enable interoperability of RDF querying libraries.
   </p>
   <p>
-    <strong>Currently, this specification only provides interfaces that enable filtering quads based on expressions.</strong>
-    Additional interfaces for more general querying support will be defined in the future.
+    <strong>Currently, this specification provides high-level interfaces such as <code>Queryable</code> for exposing querying capabilities,
+    and low-level interfaces such as <code>FilterableSource</code> for interoperability across query engines.</strong>
   </p>
 </section>
 

--- a/index.html
+++ b/index.html
@@ -245,7 +245,7 @@
     </p>
 
     <p>
-      <dfn>resultType</dfn> represents the type of query that is being executed.
+      <dfn>resultType</dfn> represents the type of query results that will be obtained for a query's execution.
       Possible values include <code>"bindings"</code>, <code>"quads"</code>, <code>"boolean"</code>, and <code>"void"</code>.
     </p>
     <p>


### PR DESCRIPTION
This PR brings the respec document up-to-date with what we defined in [`queryable-spec.ts`](https://github.com/rdfjs/query-spec/blob/master/queryable-spec.ts) (which I guess can be removed after this?). This makes everything more human-readable.